### PR TITLE
Image diff

### DIFF
--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          lfs: true
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/tests/all_tests.ts
+++ b/tests/all_tests.ts
@@ -1,3 +1,3 @@
 // @ts-ignore
-import('./teardown');
 import('./resources.spec');
+import('./fontAtlas.spec');


### PR DESCRIPTION
A lot of our tests generate images. In this PR, we add to image comparison. This will compare the image output of the branch with that of main. If any pictures are different, we should not be able to merge and get an image diff log.